### PR TITLE
Add encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for document encoding. 
+
 ### Fixed
 
-- Fixed issue parsing apostrophe control symbol.
+- Fixed issue parsing apostrophe control symbol, where a conditional was using the wrong symbol name.
+- Fixed issue parsing other tokens, where they caused a variable-not-defined exception to be thrown during parsing.
 
 ## [0.5.0] - 2021-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue parsing apostrophe control symbol.
+
 ## [0.5.0] - 2021-11-04
 
 ### Added

--- a/src/Document.php
+++ b/src/Document.php
@@ -12,6 +12,8 @@ class Document
 
     private Service\Render $render;
 
+    private Service\Encode $encode;
+
     private Element\Group $root;
 
     public function getRoot(): ?Element\Group
@@ -25,6 +27,7 @@ class Document
 
         $this->lex    = new Service\Lex\Document();
         $this->parse  = new Service\Parse\Document();
+        $this->encode = new Service\Encode();
         $this->render = new Service\Render();
         $this->output = new Service\Write();
 
@@ -50,6 +53,8 @@ class Document
         }
 
         $group = ($this->parse)($tokens);
+
+        ($this->encode)($group);
 
         $this->root = ($this->render)($group);
     }

--- a/src/Element/Control/Symbol/Apostrophe.php
+++ b/src/Element/Control/Symbol/Apostrophe.php
@@ -16,6 +16,11 @@ class Apostrophe extends Symbol
         parent::__construct('\'', $parameter);
     }
 
+    public function getEncoding(): string
+    {
+        return $this->encoding;
+    }
+
     public function setEncoding(string $encoding): self
     {
         $this->encoding = $encoding;

--- a/src/Element/Control/Symbol/Apostrophe.php
+++ b/src/Element/Control/Symbol/Apostrophe.php
@@ -5,25 +5,31 @@ namespace Jstewmc\Rtf\Element\Control\Symbol;
 /**
  * The apostrophe control symbol ("\'hh") is used to represent a non-ASCII
  * character from a Windows Code Page. The two digits "hh" are a hexadecimal
- * value for the given character on the given code page.
- *
- * The current code page is specified by the "\ansicpg" control word.
+ * value for the given character in the given encoding.
  */
 class Apostrophe extends Symbol
 {
+    private string $encoding = 'windows-1252';
+
     public function __construct(string $parameter)
     {
         parent::__construct('\'', $parameter);
     }
 
+    public function setEncoding(string $encoding): self
+    {
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
     protected function toHtml(): string
     {
-        // parameter is hexadecimal number
-        return "&#x{$this->parameter};";
+        return $this->toText();
     }
 
     protected function toText(): string
     {
-        return html_entity_decode($this->toHtml());
+        return iconv($this->encoding, 'UTF-8', hex2bin($this->parameter));
     }
 }

--- a/src/Element/Control/Word/Ansi.php
+++ b/src/Element/Control/Word/Ansi.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * The "\ansi" control word is one of the four supported character set
+ * declarations, which must be declared after the "\rtf" control word. It
+ * usually indicates the "windows-1252", but you should check the "\ansicpg"
+ * control word to be sure. 
+ */
+class Ansi extends Word
+{
+    public function __construct()
+    {
+        parent::__construct('ansi');
+    }
+
+    public function getEncoding(): string
+    {
+        return 'windows-1252';
+    }
+}

--- a/src/Element/Control/Word/Ansicpg.php
+++ b/src/Element/Control/Word/Ansicpg.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * The "\ansicpg" control word should follow the "\ansi" character set
+ * declaration, as the third control word in the document, to declare the ANSI
+ * code page to use when converting between Unicode and ANSI.
+ */
+class Ansicpg extends Word
+{
+    /**
+     * An array of `iconv` encodings, indexed by code page number.
+     */
+    private const ENCODINGS = [
+        708  => 'ISO-8859-6',
+        1252 => 'windows-1252'
+    ];
+
+    public function __construct(int $parameter)
+    {
+        parent::__construct('ansicpg', $parameter);
+    }
+
+    public function getEncoding(): string
+    {
+        if (array_key_exists($this->parameter, self::ENCODINGS)) {
+            return self::ENCODINGS[$this->parameter];
+        }
+
+        return "windows-{$this->parameter}";
+    }
+}

--- a/src/Element/Control/Word/Mac.php
+++ b/src/Element/Control/Word/Mac.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * The "\mac" control word is one of the four supported character set
+ * declarations, which must be declared after the "\rtf" control word. It
+ * indicates the "Apple Macintosh" character set.
+ */
+class Mac extends Word
+{
+    public function __construct()
+    {
+        parent::__construct('mac');
+    }
+
+    public function getEncoding(): string
+    {
+        return 'macintosh';
+    }
+}

--- a/src/Element/Control/Word/Pc.php
+++ b/src/Element/Control/Word/Pc.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * The "\pc" control word is one of the four supported character set
+ * declarations, which must be declared after the "\rtf" control word. It
+ * indicates the "IBM PC code page 437" character set.
+ */
+class Pc extends Word
+{
+    public function __construct()
+    {
+        parent::__construct('pc');
+    }
+
+    public function getEncoding(): string
+    {
+        return 'IBM437';
+    }
+}

--- a/src/Element/Control/Word/Pca.php
+++ b/src/Element/Control/Word/Pca.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * The "\pca" control word is one of the four supported character set
+ * declarations, which must be declared after the "\rtf" control word. It
+ * indicates the "IBM PC code page 850" character set.
+ */
+class Pca extends Word
+{
+    public function __construct()
+    {
+        parent::__construct('pca');
+    }
+
+    public function getEncoding(): string
+    {
+        return 'IBM850';
+    }
+}

--- a/src/Element/Control/Word/Rtf.php
+++ b/src/Element/Control/Word/Rtf.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * The "\rtf" control word must follow the document's opening bracket and
+ * declare the major version of the RTF specification used (e.g., "\rtf1").
+ */
+class Rtf extends Word
+{
+    public function __construct(int $parameter)
+    {
+        parent::__construct('rtf', $parameter);
+    }
+}

--- a/src/Service/DetectEncoding.php
+++ b/src/Service/DetectEncoding.php
@@ -5,10 +5,11 @@ namespace Jstewmc\Rtf\Service;
 use Jstewmc\Rtf\Element;
 
 /**
- * Detects the well-formed document's encoding
+ * Detects a (well-formed) document's encoding
  *
- * In a well-formed RTF document, two control words - a mandatory character set
- * and an optional code page - determine the document's character encoding:
+ * In a well-formed RTF document, two control words in the header - a mandatory
+ * character set and an optional code page - determine the document's character
+ * encoding:
  *
  *   1. When the character set is not "\ansi" (i.e., "\pc", "\pca", or "\mac"),
  *      the character set's encoding takes precedence.
@@ -75,7 +76,8 @@ class DetectEncoding
 
     private function hasCodePage(Element\Group $root): bool
     {
-        return $root->getChild(2) instanceof Element\Control\Word\Ansicpg;
+        return $root->hasChild(2) &&
+            $root->getChild(2) instanceof Element\Control\Word\Ansicpg;
     }
 
     private function getEncodingFromCharacterSet(Element\Group $root): string

--- a/src/Service/DetectEncoding.php
+++ b/src/Service/DetectEncoding.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Jstewmc\Rtf\Service;
+
+use Jstewmc\Rtf\Element;
+
+/**
+ * Detects the well-formed document's encoding
+ *
+ * In a well-formed RTF document, two control words - a mandatory character set
+ * and an optional code page - determine the document's character encoding:
+ *
+ *   1. When the character set is not "\ansi" (i.e., "\pc", "\pca", or "\mac"),
+ *      the character set's encoding takes precedence.
+ *   2. When the character set is "\ansi" but a code page does not exist, the
+ *      default ANSI code page "windows-1252" take precedence.
+ *   3. When the character set is "\ansi" and a code page does exist, it takes
+ *      precendence.
+ *
+ * If the document is not well-formed, the $default encoding is returned.
+ */
+class DetectEncoding
+{
+    public function __invoke(Element\Group $root, string $default = 'windows-1252'): string
+    {
+        if (!$this->isWellFormed($root)) {
+            return $default;
+        }
+
+        if ($this->codePageHasPrecedence($root)) {
+            $encoding = $this->getEncodingFromCodePage($root);
+        } else {
+            $encoding = $this->getEncodingFromCharacterSet($root);
+        }
+
+        return $encoding;
+    }
+
+    private function isWellFormed(Element\Group $root): bool
+    {
+        return $this->hasLength($root) &&
+            $this->hasVersion($root) &&
+            $this->hasCharacterSet($root);
+    }
+
+    private function hasLength(Element\Group $root): bool
+    {
+        return $root->getLength() >= 2;
+    }
+
+    private function hasVersion(Element\Group $root): bool
+    {
+        return $root->getFirstChild() instanceof Element\Control\Word\Rtf;
+    }
+
+    private function hasCharacterSet(Element\Group $root): bool
+    {
+        $element = $root->getChild(1);
+
+        return $element instanceof Element\Control\Word\Ansi ||
+            $element instanceof Element\Control\Word\Pc ||
+            $element instanceof Element\Control\Word\Pca ||
+            $element instanceof Element\Control\Word\Mac;
+    }
+
+    private function codePageHasPrecedence(Element\Group $root): bool
+    {
+        return $this->isAnsiCharacterSet($root) && $this->hasCodePage($root);
+    }
+
+    private function isAnsiCharacterSet(Element\Group $root): bool
+    {
+        return $this->getCharacterSet($root) instanceof Element\Control\Word\Ansi;
+    }
+
+    private function hasCodePage(Element\Group $root): bool
+    {
+        return $root->getChild(2) instanceof Element\Control\Word\Ansicpg;
+    }
+
+    private function getEncodingFromCharacterSet(Element\Group $root): string
+    {
+        return $this->getCharacterSet($root)->getEncoding();
+    }
+
+    private function getCharacterSet(Element\Group $root): Element\Control\Word\Word
+    {
+        return $root->getChild(1);
+    }
+
+    private function getEncodingFromCodePage(Element\Group $root): string
+    {
+        return $this->getCodePage($root)->getEncoding();
+    }
+
+    private function getCodePage(Element\Group $root): Element\Control\Word\Ansicpg
+    {
+        return $root->getChild(2);
+    }
+}

--- a/src/Service/Encode.php
+++ b/src/Service/Encode.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jstewmc\Rtf\Service;
+
+use Jstewmc\Rtf\Element;
+
+/**
+ * Once a document has been parsed, its encoding can be detected and the
+ * appropriate elements updated.
+ */
+class Encode
+{
+    private DetectEncoding $detectEncoding;
+
+    public function __construct()
+    {
+        $this->detectEncoding = new DetectEncoding();
+    }
+
+    public function __invoke(Element\Group $root): void
+    {
+        $encoding = ($this->detectEncoding)($root);
+
+        $this->encodeApostrophes($root, $encoding);
+    }
+
+    private function encodeApostrophes(Element\Group $root, string $encoding): void
+    {
+        $elements = $root->getControlSymbols('\'');
+
+        foreach ($elements as $element) {
+            $element->setEncoding($encoding);
+        }
+    }
+}

--- a/src/Service/Parse/ControlSymbol.php
+++ b/src/Service/Parse/ControlSymbol.php
@@ -64,7 +64,7 @@ class ControlSymbol
     {
         $classname = $this->getClassname($token->getSymbol());
 
-        if ($classname === 'asterisk') {
+        if ($token->getSymbol() === '\'') {
             $element = new $classname($token->getParameter());
         } else {
             $element = new $classname();

--- a/src/Service/Parse/ControlWord.php
+++ b/src/Service/Parse/ControlWord.php
@@ -9,12 +9,14 @@ use Jstewmc\Rtf\{
 
 class ControlWord
 {
+    private const WORDS_WITH_PARAMETER = ['rtf', 'ansicpg'];
+
     public function __invoke(Token $token): Element
     {
         $word = $token->getWord();
 
         if ($this->hasClass($word)) {
-            $element = $this->parseSpecific($word);
+            $element = $this->parseSpecific($token);
         } else {
             $element = $this->parseGeneric($word);
         }
@@ -35,11 +37,22 @@ class ControlWord
         return 'Jstewmc\\Rtf\\Element\\Control\\Word\\'.ucfirst($word);
     }
 
-    private function parseSpecific(string $word): Element
+    private function parseSpecific(Token $token): Element
     {
-        $classname = $this->getClassname($word);
+        $classname = $this->getClassname($token->getWord());
 
-        return new $classname();
+        if ($this->hasParameter($token->getWord())) {
+            $element = new $classname($token->getParameter());
+        } else {
+            $element = new $classname();
+        }
+
+        return $element;
+    }
+
+    private function hasParameter(string $word): bool
+    {
+        return in_array($word, self::WORDS_WITH_PARAMETER);
     }
 
     private function parseGeneric(string $word): Element

--- a/src/Service/Parse/Document.php
+++ b/src/Service/Parse/Document.php
@@ -89,6 +89,10 @@ class Document
 
     private function parseGroupMember(Token\Token $token): void
     {
+        if ($token instanceof Token\Other) {
+            return;
+        }
+
         if ($token instanceof Token\Control\Word) {
             $element = ($this->parseControlWord)($token);
         } elseif ($token instanceof Token\Control\Symbol) {

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -38,8 +38,13 @@ class Snippet extends Element\Group
         // lex the stream
         $tokens = (new Service\Lex\Document())($stream);
 
+        // parse the group
+        $group = (new Service\Parse\Document())($tokens);
+
+        (new Service\Encode())($group);
+
         // parse and render the tokens
-        $group = (new Service\Render())((new Service\Parse\Document())($tokens));
+        $group = (new Service\Render())($group);
 
         // set the snippet's properties from the group
         $this->parent     = null;

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -66,6 +66,16 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo', (new Document('{\b foo\b0}'))->write('text'));
     }
 
+    public function testWriteReturnsStringWhenEncodingIsDeclared(): void
+    {
+        // A nowdoc is easier than juggling the backslash and quotation marks.
+        $rtf = <<<'RTF'
+            {\rtf1\mac \'80}
+            RTF;
+
+        $this->assertEquals('Ä', (new Document($rtf))->write('text'));
+    }
+
     public function testSaveThrowsInvalidArgumentExceptionWhenFormatIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Element/Control/Symbol/ApostropheTest.php
+++ b/tests/Element/Control/Symbol/ApostropheTest.php
@@ -9,16 +9,54 @@ class ApostropheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('\'', (new Apostrophe('1'))->getSymbol());
     }
 
+    public function testSetEncodingReturnsSelf(): void
+    {
+        $symbol = new Apostrophe('1');
+
+        $this->assertSame($symbol, $symbol->setEncoding('ISO-8859-6'));
+    }
+
     public function testFormatReturnsStringWhenFormatIsHtml(): void
     {
-        $this->assertEquals('&#x22;', (new Apostrophe('22'))->format('html'));
+        $this->assertEquals(
+            $this->characterAnsi(),
+            (new Apostrophe($this->parameter()))->format('html')
+        );
     }
 
     public function testFormatReturnsStringWhenFormatIsText(): void
     {
         $this->assertEquals(
-            html_entity_decode('&#x22;'),
-            (new Apostrophe('22'))->format('text')
+            $this->characterAnsi(),
+            (new Apostrophe($this->parameter()))->format('text')
         );
+    }
+
+    public function testFormatReturnsStringWhenEncodingIsNotDefault(): void
+    {
+        $symbol = new Apostrophe($this->parameter());
+        $symbol->setEncoding('macintosh');
+
+        $this->assertEquals(
+            $this->characterMacintosh(),
+            $symbol->format('text')
+        );
+    }
+
+    private function parameter(): string
+    {
+        return '80';  // 128 in hex
+    }
+
+    private function characterAnsi(): string
+    {
+        // the 128th character in the "windows-1252" (aka, "ansi") character set
+        return '€';
+    }
+
+    private function characterMacintosh(): string
+    {
+        // the 128th character in the "macintosh" character set
+        return 'Ä';
     }
 }

--- a/tests/Element/Control/Symbol/ApostropheTest.php
+++ b/tests/Element/Control/Symbol/ApostropheTest.php
@@ -9,6 +9,11 @@ class ApostropheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('\'', (new Apostrophe('1'))->getSymbol());
     }
 
+    public function testGetEncodingReturnsString(): void
+    {
+        $this->assertEquals('windows-1252', (new Apostrophe('1'))->getEncoding());
+    }
+
     public function testSetEncodingReturnsSelf(): void
     {
         $symbol = new Apostrophe('1');

--- a/tests/Element/Control/Word/AnsiTest.php
+++ b/tests/Element/Control/Word/AnsiTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class AnsiTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('ansi', (new Ansi())->getWord());
+    }
+}

--- a/tests/Element/Control/Word/AnsicpgTest.php
+++ b/tests/Element/Control/Word/AnsicpgTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class AnsicpgTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('ansicpg', (new Ansicpg(1))->getWord());
+    }
+
+    public function testGetEncodingReturnsStringWhenCodePageIsSupported(): void
+    {
+        $this->assertEquals('windows-1252', (new Ansicpg(1252))->getEncoding());
+    }
+
+    public function testGetEncodingReturnsStringWhenCodePageIsNotSupported(): void
+    {
+        $this->assertEquals('windows-999', (new Ansicpg(999))->getEncoding());
+    }
+}

--- a/tests/Element/Control/Word/MacTest.php
+++ b/tests/Element/Control/Word/MacTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class MacTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('mac', (new Mac())->getWord());
+    }
+
+    public function testGetEncodingReturnsString(): void
+    {
+        $this->assertEquals('macintosh', (new Mac())->getEncoding());
+    }
+}

--- a/tests/Element/Control/Word/PcTest.php
+++ b/tests/Element/Control/Word/PcTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class PcTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('pc', (new Pc())->getWord());
+    }
+
+    public function testGetEncodingReturnsString(): void
+    {
+        $this->assertEquals('IBM437', (new Pc())->getEncoding());
+    }
+}

--- a/tests/Element/Control/Word/PcaTest.php
+++ b/tests/Element/Control/Word/PcaTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class PcaTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('pca', (new Pca())->getWord());
+    }
+
+    public function testGetEncodingReturnsString(): void
+    {
+        $this->assertEquals('IBM850', (new Pca())->getEncoding());
+    }
+}

--- a/tests/Element/Control/Word/RtfTest.php
+++ b/tests/Element/Control/Word/RtfTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class RtfTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('rtf', (new Rtf(1))->getWord());
+    }
+}

--- a/tests/Service/DetectEncodingTest.php
+++ b/tests/Service/DetectEncodingTest.php
@@ -86,4 +86,19 @@ class DetectEncodingTest extends \PHPUnit\Framework\TestCase
             ->appendChild(new Element\Control\Word\Ansicpg(708))
             ->appendChild(new Element\Text('foo'));
     }
+
+    public function testInvokeReturnsStringWhenEncodingIsAnsiWithoutCodePage(): void
+    {
+        $this->assertEquals(
+            'windows-1252',
+            (new DetectEncoding())($this->groupWithAnsiWithoutCodePage())
+        );
+    }
+
+    private function groupWithAnsiWithoutCodePage(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\Ansi());
+    }
 }

--- a/tests/Service/DetectEncodingTest.php
+++ b/tests/Service/DetectEncodingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Jstewmc\Rtf\Service;
+
+use Jstewmc\Rtf\Element;
+
+class DetectEncodingTest extends \PHPUnit\Framework\TestCase
+{
+    public function testInvokeReturnsDefaultWhenVersionIsMissing(): void
+    {
+        $this->assertEquals(
+            'windows-1252',
+            (new DetectEncoding())($this->groupWithoutVersion())
+        );
+    }
+
+    private function groupWithoutVersion(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\B())
+            ->appendChild(new Element\Text('foo'))
+            ->appendChild(new Element\Control\Word\B(0));
+    }
+
+    public function testInvokeReturnsDefaultWhenCharacterSetIsMissing(): void
+    {
+        $this->assertEquals(
+            'windows-1252',
+            (new DetectEncoding())($this->groupWithoutCharacterSet())
+        );
+    }
+
+    private function groupWithoutCharacterSet(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Text('foo'));
+    }
+
+    public function testInvokeReturnsStringWhenCodePageIsMissing(): void
+    {
+        $this->assertEquals(
+            'windows-1252',
+            (new DetectEncoding())($this->groupWithoutCodePage())
+        );
+    }
+
+    private function groupWithoutCodePage(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\Ansi())
+            ->appendChild(new Element\Text('foo'));
+    }
+
+    public function testInvokeReturnsStringWhenEncodingIsFromCharacterSet(): void
+    {
+        $this->assertEquals(
+            'macintosh',
+            (new DetectEncoding())($this->groupWithCharacterSetEncoding())
+        );
+    }
+
+    private function groupWithCharacterSetEncoding(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\Mac())
+            ->appendChild(new Element\Control\Word\Ansicpg(1))
+            ->appendChild(new Element\Text('foo'));
+    }
+
+    public function testInvokeReturnsStringWhenEncodingIsFromCodePage(): void
+    {
+        $this->assertEquals(
+            'ISO-8859-6',
+            (new DetectEncoding())($this->groupWithCodePageEncoding())
+        );
+    }
+
+    private function groupWithCodePageEncoding(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\Ansi())
+            ->appendChild(new Element\Control\Word\Ansicpg(708))
+            ->appendChild(new Element\Text('foo'));
+    }
+}

--- a/tests/Service/EncodeTest.php
+++ b/tests/Service/EncodeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jstewmc\Rtf\Service;
+
+use Jstewmc\Rtf\Element;
+
+class EncodeTest extends \PHPUnit\Framework\TestCase
+{
+    public function testInvokeReturnsVoidWhenGroupIsEmpty(): void
+    {
+        $this->assertNull((new Encode())(new Element\Group()));
+    }
+
+    public function testInvokeReturnsVoidWhenDocumentDoesNotHaveApostrophes(): void
+    {
+        $group = (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\Mac())
+            ->appendChild(new Element\Text('foo'));
+
+        $this->assertNull((new Encode())($group));
+    }
+
+    public function testInvokeReturnsVoidWhenGroupHasApostrophes(): void
+    {
+        $apostrophe = new Element\Control\Symbol\Apostrophe('80');
+
+        $group = (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\Mac())
+            ->appendChild($apostrophe);
+
+        (new Encode())($group);
+
+        $this->assertEquals('macintosh', $apostrophe->getEncoding());
+    }
+}

--- a/tests/Service/Parse/ControlSymbolTest.php
+++ b/tests/Service/Parse/ControlSymbolTest.php
@@ -17,6 +17,14 @@ class ControlSymbolTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testInvokeReturnsElementWhenSymbolIsApostrophe(): void
+    {
+        $this->assertEquals(
+            new Element\Apostrophe('a1'),
+            (new ControlSymbol())(new Token('\''))->setParameter('a1')
+        );
+    }
+
     public function testInvokeReturnsElementWhenSymbolIsGenerci(): void
     {
         $this->assertEquals(

--- a/tests/Service/Parse/ControlWordTest.php
+++ b/tests/Service/Parse/ControlWordTest.php
@@ -17,6 +17,14 @@ class ControlWordTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testInvokeReturnsElementWhenWordHasParameter(): void
+    {
+        $this->assertEquals(
+            new Element\Rtf(1),
+            (new ControlWord())((new Token('rtf'))->setParameter(1))
+        );
+    }
+
     public function testInvokeReturnsElementWhenWordIsGeneric(): void
     {
         $this->assertEquals(

--- a/tests/Service/Parse/DocumentTest.php
+++ b/tests/Service/Parse/DocumentTest.php
@@ -205,7 +205,6 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         return $root;
     }
 
-
     public function testInvokeParsesText(): void
     {
         $this->assertEquals(
@@ -412,5 +411,27 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
             ->appendChild($a_17);
 
         return $groupA;
+    }
+
+    public function testInvokeParsesOtherCharacterTokens(): void
+    {
+        $this->assertEquals(
+            $this->otherRoot(),
+            (new Document())($this->otherTokens())
+        );
+    }
+
+    private function otherTokens(): array
+    {
+        return [
+            new Token\Group\Open(),
+            new Token\Other("\r"),
+            new Token\Group\Close()
+        ];
+    }
+
+    private function otherRoot(): Element\Group
+    {
+        return new Element\Group();
     }
 }

--- a/tests/Service/Parse/DocumentTest.php
+++ b/tests/Service/Parse/DocumentTest.php
@@ -286,10 +286,10 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
     {
         $groupA = new Element\Group();
 
-        $a_1 = new Element\Control\Word\Word('rtf', 1);
+        $a_1 = new Element\Control\Word\Rtf(1);
         $a_1->setParent($groupA);
 
-        $a_2 = new Element\Control\Word\Word('ansi');
+        $a_2 = new Element\Control\Word\Ansi();
         $a_2->setParent($groupA);
 
         $a_3 = new Element\Control\Word\Word('deff', 0);

--- a/tests/SnippetTest.php
+++ b/tests/SnippetTest.php
@@ -25,4 +25,14 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals('\cxds ing', (new Snippet('\cxds ing'))->write());
     }
+
+    public function testWriteReturnsStringWhenEncodingIsDeclared(): void
+    {
+        // A nowdoc is easier than juggling the backslash and quotation marks.
+        $rtf = <<<'RTF'
+            \rtf1\mac \'80
+            RTF;
+
+        $this->assertEquals('Ä', (new Snippet($rtf))->write('text'));
+    }
 }

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -6,19 +6,39 @@ class SystemTest extends \PHPUnit\Framework\TestCase
 {
     public function testDocument1(): void
     {
-        $rtf = <<<RTF
+        $rtf = <<<'RTF'
             {\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil Bookman Old Style;}{\f1\fnil\fcharset0 Bookman Old Style;}} \viewkind4\uc1\pard\lang1043\f0\fs20 Histoire naturelle g\f1\'e9n\'e9rale et particuli\'e8re des crustac\'e9s et des insectes. Ouvrage faisant suite aux oeuvres de Buffon, et partie du cours complet d'histoire naturelle r\'e9dig\'e9 par C. S. Sonnini, membre de plusieurs soci\'e9t\'e9s savantes. Familles naturelles des genres. Tomes 1-14. [Complete for the Arthropoda].\f0\par }
             RTF;
 
-        $this->assertInstanceOf(Document::class, new Document($rtf));
+        $this->assertEquals($rtf, (string)(new Document($rtf)));
     }
 
     public function testDocument2(): void
     {
-        $rtf = <<<RTF
-            {\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil Bookman Old Style;}{\f1\fnil\fcharset0 Bookman Old Style;}} \viewkind4\uc1\pard\lang1043\f0\fs20 Histoire naturelle g\f1\'e9n\'e9rale et particuli\'e8re des crustac\'e9s et des insectes. Ouvrage faisant suite aux oeuvres de Buffon, et partie du cours complet d'histoire naturelle r\'e9dig\'e9 par C. S. Sonnini, membre de plusieurs soci\'e9t\'e9s savantes. Familles naturelles des genres. Tomes 1-14. [Complete for the Arthropoda].\f0\par }
+        $rtf = <<<'RTF'
+            {\rtf1\ansi\deff3\adeflang1025
+            {\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\froman\fprq2\fcharset2 Symbol;}{\f2\fswiss\fprq2\fcharset0 Arial;}{\f3\froman\fprq2\fcharset0 Liberation Serif{\*\falt Times New Roman};}{\f4\froman\fprq2\fcharset0 Liberation Sans{\*\falt Arial};}{\f5\fnil\fprq2\fcharset0 Lohit Devanagari;}{\f6\fnil\fprq2\fcharset0 Liberation Serif{\*\falt Times New Roman};}}
+            {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red201\green33\blue30;}
+            {\stylesheet{\s0\snext0\widctlpar\hyphpar0\cf0\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f3\fs24\lang3082 Normal;}
+            {\s15\sbasedon0\snext16\widctlpar\hyphpar0\sb240\sa120\keepn\cf0\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f4\fs28 Heading;}
+            {\s16\sbasedon0\snext16\sl276\slmult1\widctlpar\hyphpar0\sb0\sa140\cf0\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f3\fs24 Text Body;}
+            {\s17\sbasedon16\snext17\sl276\slmult1\widctlpar\hyphpar0\sb0\sa140\cf0\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f3\fs24 List;}
+            {\s18\sbasedon0\snext18\widctlpar\hyphpar0\sb120\sa120\cf0\i\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f3\fs24 Caption;}
+            {\s19\sbasedon0\snext19\widctlpar\hyphpar0\cf0\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f3\fs24 Index;}
+            }{\*\generator LibreOffice/6.2.2.2$Linux_X86_64 LibreOffice_project/20$Build-2}{\info{\creatim\yr2020\mo11\dy17\hr10\min43}{\revtim\yr2020\mo11\dy17\hr10\min45}{\printim\yr0\mo0\dy0\hr0\min0}}{\*\userprops}\deftab709
+            \hyphauto0\viewscale90
+            {\*\pgdsctbl
+            {\pgdsc0\pgdscuse451\pgwsxn11906\pghsxn16838\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\pgdscnxt0 Default Style;}}
+            \formshade{\*\pgdscno0}\paperh16838\paperw11906\margl1134\margr1134\margt1134\margb1134\sectd\sbknone\sectunlocked1\pgndec\pgwsxn11906\pghsxn16838\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\ftnbj\ftnstart1\ftnrstcont\ftnnar\aenddoc\aftnrstcont\aftnstart1\aftnnrlc
+            {\*\ftnsep\chftnsep}\pgndec\pard\plain \s0\widctlpar\hyphpar0\cf0\kerning1\dbch\af5\langfe1081\dbch\af6\afs24\alang3082\loch\f3\fs24\lang3082{\rtlch \ltrch\loch
+            This is a }{\cf17\b\rtlch \ltrch\loch
+            test}
+            \par }
             RTF;
 
-        $this->assertInstanceOf(Document::class, new Document($rtf));
+        $this->assertEquals(
+            str_replace("\n", '', $rtf),
+            (string)(new Document($rtf))
+        );
     }
 }

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Jstewmc\Rtf;
+
+class SystemTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDocument1(): void
+    {
+        $rtf = <<<RTF
+            {\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil Bookman Old Style;}{\f1\fnil\fcharset0 Bookman Old Style;}} \viewkind4\uc1\pard\lang1043\f0\fs20 Histoire naturelle g\f1\'e9n\'e9rale et particuli\'e8re des crustac\'e9s et des insectes. Ouvrage faisant suite aux oeuvres de Buffon, et partie du cours complet d'histoire naturelle r\'e9dig\'e9 par C. S. Sonnini, membre de plusieurs soci\'e9t\'e9s savantes. Familles naturelles des genres. Tomes 1-14. [Complete for the Arthropoda].\f0\par }
+            RTF;
+
+        $this->assertInstanceOf(Document::class, new Document($rtf));
+    }
+
+    public function testDocument2(): void
+    {
+        $rtf = <<<RTF
+            {\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fnil Bookman Old Style;}{\f1\fnil\fcharset0 Bookman Old Style;}} \viewkind4\uc1\pard\lang1043\f0\fs20 Histoire naturelle g\f1\'e9n\'e9rale et particuli\'e8re des crustac\'e9s et des insectes. Ouvrage faisant suite aux oeuvres de Buffon, et partie du cours complet d'histoire naturelle r\'e9dig\'e9 par C. S. Sonnini, membre de plusieurs soci\'e9t\'e9s savantes. Familles naturelles des genres. Tomes 1-14. [Complete for the Arthropoda].\f0\par }
+            RTF;
+
+        $this->assertInstanceOf(Document::class, new Document($rtf));
+    }
+}


### PR DESCRIPTION
Add character encoding to the library. 

Before, I had ignored character encoding as the documents I was processing were always in ASCII/ANSI/UTF-8 compatible characters. But, for others, ignoring the character set encoding broke the apostrophe control symbol (#2). 

## The rules 

I find [the specification](http://www.biblioscape.com/rtf15_spec.htm#Heading8) confusing on character sets and code pages, but these are the rules as I understand them: 

1. A document MUST declare the RTF version as the first control word (e.g., `\rtf1`).
1. A document MUST declare a character set immediately after the RTF control word. The following character set control words are supported - `\pc`, `\pca`, `\mac`, and `\ansi` (default) - and these character sets correspond to the following encoding names in `iconv`, the utility in PHP (and on your machine) that convert between [different character encodings](https://stackoverflow.com/a/8039467) - `IBM437`, `IBM850`, `macintosh`, and `windows-1252`. 
2. A document MAY declare an ANSI code page immediately after the `\ansi` character set declaration. The parameter in the control word corresponds to a [numeric code page identifier](http://latex2rtf.sourceforge.net/rtfspec_6.html#rtfspec_9) supported by RTF (e.g., `1252` corresponds to the `windows-1252` encoding in `iconv`). 
3. A document SHOULD default to `windows-1252` encoding in the absence of a well-formed document head or the proper declarations. The RTF specification requires documents to be written in "ANSI", a super-set of ASCII (ASCII + 128 characters), and (roughly) a sub-set of UTF-8. 

## Changes 

To support this functionality: 

* I added character set and code page control word elements like `rtf`, `ansi`, `pc`, etc. 
* I added a _detect-encoding_ service to detect a (well-formed) document's character encoding by inspecting its root element (defaults to `windows-1252`).
* I added an `$encoding` property to the `Apostrophe` control symbol that defaults to `windows-1252`. 
* I added an _encode_ service to encode a documents encoding-aware elements (i.e., only apostrophes for now).
* I added the encoding step to `Document` and `Snippet` processing.

Closes #2 