### PR TITLE
Add color parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for parsing font tables (but not support for styling fonts yet).
+- Added support for parsing color tables (but not support for styling colors yet).
 
 ### Changed
 

--- a/src/Element/Control/Word/Color/Blue.php
+++ b/src/Element/Control/Word/Color/Blue.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+class Blue extends Color
+{
+    public function __construct(int $index)
+    {
+        parent::__construct('blue', $index);
+    }
+}

--- a/src/Element/Control/Word/Color/Color.php
+++ b/src/Element/Control/Word/Color/Color.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+use Jstewmc\Rtf\Element\Control\Word\Word;
+
+abstract class Color extends Word
+{
+    public function getIndex(): int
+    {
+        return $this->parameter;
+    }
+}

--- a/src/Element/Control/Word/Color/Green.php
+++ b/src/Element/Control/Word/Color/Green.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+class Green extends Color
+{
+    public function __construct(int $index)
+    {
+        parent::__construct('green', $index);
+    }
+}

--- a/src/Element/Control/Word/Color/Red.php
+++ b/src/Element/Control/Word/Color/Red.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+class Red extends Color
+{
+    public function __construct(int $index)
+    {
+        parent::__construct('red', $index);
+    }
+}

--- a/src/Element/Control/Word/Colortbl.php
+++ b/src/Element/Control/Word/Colortbl.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+/**
+ * Introduces the color table group
+ */
+class Colortbl extends Word
+{
+    public function __construct()
+    {
+        parent::__construct('colortbl');
+    }
+}

--- a/src/Element/HeaderTable/ColorTable.php
+++ b/src/Element/HeaderTable/ColorTable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\HeaderTable;
+
+/**
+ * Defines screen colors, character colors, and other color information
+ */
+class ColorTable extends HeaderTable
+{
+
+}

--- a/src/Element/HeaderTable/FontTable.php
+++ b/src/Element/HeaderTable/FontTable.php
@@ -7,8 +7,5 @@ namespace Jstewmc\Rtf\Element\HeaderTable;
  */
 class FontTable extends HeaderTable
 {
-    public function __construct(array $children = [])
-    {
-        $this->setChildren($children);
-    }
+
 }

--- a/src/Element/HeaderTable/HeaderTable.php
+++ b/src/Element/HeaderTable/HeaderTable.php
@@ -11,6 +11,11 @@ use Jstewmc\Rtf\Element\Group;
  */
 abstract class HeaderTable extends Group
 {
+    public function __construct(array $children = [])
+    {
+        $this->setChildren($children);
+    }
+    
     public function toHtml(): string
     {
         return '';

--- a/tests/Element/Control/Word/Color/BlueTest.php
+++ b/tests/Element/Control/Word/Color/BlueTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+class BlueTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('blue', (new Blue(0))->getWord());
+    }
+
+    public function testGetNumberReturnsInt(): void
+    {
+        $this->assertEquals(0, (new Blue(0))->getIndex());
+    }
+}

--- a/tests/Element/Control/Word/Color/GreenTest.php
+++ b/tests/Element/Control/Word/Color/GreenTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+class GreenTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('green', (new Green(0))->getWord());
+    }
+
+    public function testGetNumberReturnsInt(): void
+    {
+        $this->assertEquals(0, (new Green(0))->getIndex());
+    }
+}

--- a/tests/Element/Control/Word/Color/RedTest.php
+++ b/tests/Element/Control/Word/Color/RedTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word\Color;
+
+class RedTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('red', (new Red(0))->getWord());
+    }
+
+    public function testGetNumberReturnsInt(): void
+    {
+        $this->assertEquals(0, (new Red(0))->getIndex());
+    }
+}

--- a/tests/Element/Control/Word/ColortblTest.php
+++ b/tests/Element/Control/Word/ColortblTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\Control\Word;
+
+class ColortblTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetWordReturnsString(): void
+    {
+        $this->assertEquals('colortbl', (new Colortbl())->getWord());
+    }
+}

--- a/tests/Element/HeaderTable/ColorTableTest.php
+++ b/tests/Element/HeaderTable/ColorTableTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jstewmc\Rtf\Element\HeaderTable;
+
+class ColorTableTest extends \PHPUnit\Framework\TestCase
+{
+    public function testToHtmlReturnsString(): void
+    {
+        $this->assertEquals('', (new ColorTable())->toHtml());
+    }
+
+    public function testToTextReturnsString(): void
+    {
+        $this->assertEquals('', (new ColorTable())->toText());
+    }
+}

--- a/tests/Service/Parse/DocumentTest.php
+++ b/tests/Service/Parse/DocumentTest.php
@@ -260,6 +260,14 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
             new Token\Group\Close(),
             new Token\Group\Close(),
             new Token\Group\Open(),
+            new Token\Control\Word('colortbl'),
+            new Token\Text(';'),
+            (new Token\Control\Word('red'))->setParameter(0),
+            (new Token\Control\Word('green'))->setParameter(0),
+            (new Token\Control\Word('blue'))->setParameter(0),
+            new Token\Text(';'),
+            new Token\Group\Close(),
+            new Token\Group\Open(),
             new Token\Control\Symbol('*'),
             new Token\Control\Word('generator'),
             new Token\Text('Msftedit 5.41.15.1516;'),
@@ -289,6 +297,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
             ->appendChild(new Element\Control\Word\CharacterSet\Ansi())
             ->appendChild(new Element\Control\Word\Deff(0))
             ->appendChild($this->fontTableGroup())
+            ->appendChild($this->colorTableGroup())
             ->appendChild($this->generatorGroup())
             ->appendChild(new Element\Control\Word\Word('viewkind', 4))
             ->appendChild(new Element\Control\Word\Word('uc', 1))
@@ -320,6 +329,17 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
             ->appendChild(new Element\Control\Word\FontFamily\Fnil())
             ->appendChild(new Element\Control\Word\Fcharset(0))
             ->appendChild(new Element\Text('Courier New;'));
+    }
+
+    private function colorTableGroup(): Element\HeaderTable\ColorTable
+    {
+        return (new Element\HeaderTable\ColorTable())
+            ->appendChild(new Element\Control\Word\Colortbl())
+            ->appendChild(new Element\Text(';'))
+            ->appendChild(new Element\Control\Word\Color\Red(0))
+            ->appendChild(new Element\Control\Word\Color\Green(0))
+            ->appendChild(new Element\Control\Word\Color\Blue(0))
+            ->appendChild(new Element\Text(';'));
     }
 
     private function generatorGroup(): Element\Group

--- a/tests/Service/Parse/HeaderTableTest.php
+++ b/tests/Service/Parse/HeaderTableTest.php
@@ -6,7 +6,7 @@ use Jstewmc\Rtf\Element;
 
 class HeaderTableTest extends \PHPUnit\Framework\TestCase
 {
-    public function testInvokeReturnsGroupWhenFontTableDoesNotExist(): void
+    public function testInvokeReturnsGroupWhenHeaderTableDoesNotExist(): void
     {
         $root = $this->rootWithoutFontTable();
 
@@ -21,7 +21,7 @@ class HeaderTableTest extends \PHPUnit\Framework\TestCase
             ->appendChild(new Element\Text('foo'));
     }
 
-    public function testInvokeReturnsGroupWhenFontTableDoesExist(): void
+    public function testInvokeReturnsGroupWhenFontTableExists(): void
     {
         $root = $this->rootWithFontTable();
 
@@ -66,5 +66,43 @@ class HeaderTableTest extends \PHPUnit\Framework\TestCase
             ->appendChild(new Element\Control\Word\FontFamily\Fnil())
             ->appendChild(new Element\Control\Word\Fcharset(0))
             ->appendChild(new Element\Text('Bookman Old Style;'));
+    }
+
+    public function testInvokeReturnsGroupWhenColorTableExists(): void
+    {
+        $root = $this->rootWithColorTable();
+
+        $root = (new HeaderTable())($root);
+
+        $this->assertInstanceOf(Element\HeaderTable\ColorTable::class, $root->getChild(3));
+    }
+
+    private function rootWithColorTable(): Element\Group
+    {
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Rtf(1))
+            ->appendChild(new Element\Control\Word\CharacterSet\Mac())
+            ->appendChild(new Element\Control\Word\Deff(0))
+            ->appendChild($this->colorTable())
+            ->appendChild(new Element\Text('foo'));
+    }
+
+    private function colorTable(): Element\Group
+    {
+        // e.g., "{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;}"
+        return (new Element\Group())
+            ->appendChild(new Element\Control\Word\Colortbl())
+            ->appendChild(new Element\Text(';'))
+            ->appendChild(new Element\Control\Word\Color\Red(0))
+            ->appendChild(new Element\Control\Word\Color\Green(0))
+            ->appendChild(new Element\Control\Word\Color\Blue(0))
+            ->appendChild(new Element\Text(';'))
+            ->appendChild(new Element\Control\Word\Color\Red(0))
+            ->appendChild(new Element\Control\Word\Color\Green(0))
+            ->appendChild(new Element\Control\Word\Color\Blue(255))
+            ->appendChild(new Element\Text(';'))
+            ->appendChild(new Element\Control\Word\Color\Red(0))
+            ->appendChild(new Element\Control\Word\Color\Green(255))
+            ->appendChild(new Element\Control\Word\Color\Blue(255));
     }
 }

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -32,7 +32,7 @@ class SystemTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             // This will improve as we add support for color tables and stylesheets.
-            ';;;;;;;;;;;;;;;;;;Normal;Heading;Text Body;List;Caption;Index;This is a test',
+            'Normal;Heading;Text Body;List;Caption;Index;This is a test',
             (new Document($this->document2()))->write('text')
         );
     }


### PR DESCRIPTION
Add support for parsing color tables: 

* Add color table control words
* Change the parse-header-table service to include color tables
* Add color tables to the parse-document test and update the rtf-to-text conversion system test